### PR TITLE
Split sphere client into request scoped and singleton for usage outside controllers

### DIFF
--- a/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeProvider.java
+++ b/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeProvider.java
@@ -14,7 +14,7 @@ public final class CategoryTreeProvider implements Provider<CategoryTree> {
     private static final Logger logger = LoggerFactory.getLogger(CategoryTreeProvider.class);
 
     @Inject
-    @Named("singleton")
+    @Named("global")
     private SphereClient client;
 
     @Override

--- a/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeProvider.java
+++ b/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeProvider.java
@@ -8,11 +8,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 public final class CategoryTreeProvider implements Provider<CategoryTree> {
     private static final Logger logger = LoggerFactory.getLogger(CategoryTreeProvider.class);
 
     @Inject
+    @Named("singleton")
     private SphereClient client;
 
     @Override

--- a/common/app/com/commercetools/sunrise/common/contexts/ContextDataModule.java
+++ b/common/app/com/commercetools/sunrise/common/contexts/ContextDataModule.java
@@ -14,12 +14,10 @@ public class ContextDataModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        final RequestScope requestScope = new RequestScope();
-        bindScope(RequestScoped.class, requestScope);
-        bind(Http.Context.class).toProvider(HttpContextProvider.class).in(requestScope);
-        bind(UserContext.class).toProvider(UserContextProvider.class).in(requestScope);
-        bind(RequestContext.class).toProvider(RequestContextProvider.class).in(requestScope);
+        bind(Http.Context.class).toProvider(HttpContextProvider.class).in(RequestScoped.class);
+        bind(UserContext.class).toProvider(UserContextProvider.class).in(RequestScoped.class);
+        bind(RequestContext.class).toProvider(RequestContextProvider.class).in(RequestScoped.class);
         bind(ProjectContext.class).toProvider(ProjectContextProvider.class).in(Singleton.class);
-        bind(RequestHookContext.class).to(RequestHookContextImpl.class).in(requestScope);
+        bind(RequestHookContext.class).to(RequestHookContextImpl.class).in(RequestScoped.class);
     }
 }

--- a/common/app/com/commercetools/sunrise/common/contexts/ProjectContextProvider.java
+++ b/common/app/com/commercetools/sunrise/common/contexts/ProjectContextProvider.java
@@ -31,7 +31,7 @@ public final class ProjectContextProvider implements Provider<ProjectContext> {
     @Inject
     private Configuration configuration;
     @Inject
-    @Named("singleton")
+    @Named("global")
     private SphereClient client;
 
     @Override

--- a/common/app/com/commercetools/sunrise/common/contexts/ProjectContextProvider.java
+++ b/common/app/com/commercetools/sunrise/common/contexts/ProjectContextProvider.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import play.Configuration;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.money.CurrencyUnit;
 import javax.money.Monetary;
 import java.util.List;
@@ -30,6 +31,7 @@ public final class ProjectContextProvider implements Provider<ProjectContext> {
     @Inject
     private Configuration configuration;
     @Inject
+    @Named("singleton")
     private SphereClient client;
 
     @Override

--- a/common/app/com/commercetools/sunrise/common/contexts/RequestScopeModule.java
+++ b/common/app/com/commercetools/sunrise/common/contexts/RequestScopeModule.java
@@ -1,0 +1,11 @@
+package com.commercetools.sunrise.common.contexts;
+
+import com.google.inject.AbstractModule;
+
+public class RequestScopeModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bindScope(RequestScoped.class, new RequestScope());
+    }
+}

--- a/common/app/com/commercetools/sunrise/common/ctp/CtpModule.java
+++ b/common/app/com/commercetools/sunrise/common/ctp/CtpModule.java
@@ -2,6 +2,7 @@ package com.commercetools.sunrise.common.ctp;
 
 import com.commercetools.sunrise.common.contexts.RequestScoped;
 import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
 import io.sphere.sdk.client.SphereAccessTokenSupplier;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.client.SphereClientConfig;
@@ -20,6 +21,7 @@ public class CtpModule extends AbstractModule {
         bind(HttpClient.class).toInstance(SphereClientFactory.of().createHttpClient());
         bind(SphereClientConfig.class).toProvider(SphereClientConfigProvider.class).in(Singleton.class);
         bind(SphereAccessTokenSupplier.class).toProvider(SphereAccessTokenSupplierProvider.class).in(Singleton.class);
+        bind(SphereClient.class).annotatedWith(Names.named("singleton")).toProvider(SphereClientProvider.class).in(Singleton.class);
         bind(SphereClient.class).toProvider(RequestScopedSphereClientProvider.class).in(RequestScoped.class);
         bind(ProductDataConfig.class).toProvider(ProductDataConfigProvider.class).in(Singleton.class);
     }

--- a/common/app/com/commercetools/sunrise/common/ctp/CtpModule.java
+++ b/common/app/com/commercetools/sunrise/common/ctp/CtpModule.java
@@ -21,7 +21,7 @@ public class CtpModule extends AbstractModule {
         bind(HttpClient.class).toInstance(SphereClientFactory.of().createHttpClient());
         bind(SphereClientConfig.class).toProvider(SphereClientConfigProvider.class).in(Singleton.class);
         bind(SphereAccessTokenSupplier.class).toProvider(SphereAccessTokenSupplierProvider.class).in(Singleton.class);
-        bind(SphereClient.class).annotatedWith(Names.named("singleton")).toProvider(SphereClientProvider.class).in(Singleton.class);
+        bind(SphereClient.class).annotatedWith(Names.named("global")).toProvider(SphereClientProvider.class).in(Singleton.class);
         bind(SphereClient.class).toProvider(RequestScopedSphereClientProvider.class).in(RequestScoped.class);
         bind(ProductDataConfig.class).toProvider(ProductDataConfigProvider.class).in(Singleton.class);
     }

--- a/common/app/com/commercetools/sunrise/common/ctp/ProductDataConfigProvider.java
+++ b/common/app/com/commercetools/sunrise/common/ctp/ProductDataConfigProvider.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import play.Configuration;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -27,6 +28,7 @@ public final class ProductDataConfigProvider implements Provider<ProductDataConf
     @Inject
     private Configuration configuration;
     @Inject
+    @Named("singleton")
     private SphereClient client;
 
     @Override

--- a/common/app/com/commercetools/sunrise/common/ctp/ProductDataConfigProvider.java
+++ b/common/app/com/commercetools/sunrise/common/ctp/ProductDataConfigProvider.java
@@ -28,7 +28,7 @@ public final class ProductDataConfigProvider implements Provider<ProductDataConf
     @Inject
     private Configuration configuration;
     @Inject
-    @Named("singleton")
+    @Named("global")
     private SphereClient client;
 
     @Override

--- a/common/app/com/commercetools/sunrise/common/ctp/SphereClientProvider.java
+++ b/common/app/com/commercetools/sunrise/common/ctp/SphereClientProvider.java
@@ -8,14 +8,13 @@ import io.sphere.sdk.http.HttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.inject.ApplicationLifecycle;
-import play.mvc.Http;
 
 import javax.inject.Inject;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
-public final class RequestScopedSphereClientProvider implements Provider<SphereClient> {
-    private static final Logger logger = LoggerFactory.getLogger(RequestScopedSphereClientProvider.class);
+public final class SphereClientProvider implements Provider<SphereClient> {
+    private static final Logger logger = LoggerFactory.getLogger(SphereClientProvider.class);
 
     @Inject
     private ApplicationLifecycle applicationLifecycle;
@@ -25,14 +24,11 @@ public final class RequestScopedSphereClientProvider implements Provider<SphereC
     private SphereAccessTokenSupplier sphereAccessTokenSupplier;
     @Inject
     private SphereClientConfig sphereClientConfig;
-    @Inject
-    private Http.Context context;
 
     @Override
     public SphereClient get() {
-        final MetricHttpClient metricHttpClient = MetricHttpClient.of(httpClient, context);
-        logger.info("Provide RequestScopedSphereClient: MetricHttpClient");
-        final SphereClient sphereClient = SphereClient.of(sphereClientConfig, metricHttpClient, sphereAccessTokenSupplier);
+        SphereClient sphereClient = SphereClient.of(sphereClientConfig, httpClient, sphereAccessTokenSupplier);
+        logger.info("Provide SphereClient");
         applicationLifecycle.addStopHook(() -> {
             sphereClient.close();
             return completedFuture(null);

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -300,6 +300,7 @@ play.crypto.secret=${?APPLICATION_SECRET}
 play.application.loader = "com.commercetools.sunrise.common.configuration.SunriseApplicationLoader"
 play.http.filters = "com.commercetools.sunrise.common.basicauth.BasicAuthHttpFilters"
 
+play.modules.enabled += "com.commercetools.sunrise.common.contexts.RequestScopeModule"
 play.modules.enabled += "demo.common.ComponentsModule"
 play.modules.enabled += "com.commercetools.sunrise.common.contexts.ContextDataModule"
 play.modules.enabled += "com.commercetools.sunrise.common.basicauth.BasicAuthModule"


### PR DESCRIPTION
Fixes issue on production with failed Injector creation due to missing Http Context