### PR TITLE
Fix product with no categories suggestion issue

### DIFF
--- a/common/app/com/commercetools/sunrise/common/suggestion/SunriseProductRecommendation.java
+++ b/common/app/com/commercetools/sunrise/common/suggestion/SunriseProductRecommendation.java
@@ -47,11 +47,15 @@ public class SunriseProductRecommendation implements ProductRecommendation {
         final Set<String> categoryIds = product.getCategories().stream()
                 .map(Reference::getId)
                 .collect(toSet());
-        return productsFromCategoryIds(categoryIds, numProducts + 1)
-                .thenApply(products -> products.stream()
-                        .filter(p -> !p.getId().equals(product.getId()))
-                        .limit(numProducts)
-                        .collect(toSet()));
+        if (categoryIds.isEmpty()) {
+            return CompletableFuture.completedFuture(emptySet());
+        } else {
+            return productsFromCategoryIds(categoryIds, numProducts + 1)
+                    .thenApply(products -> products.stream()
+                            .filter(p -> !p.getId().equals(product.getId()))
+                            .limit(numProducts)
+                            .collect(toSet()));
+        }
     }
 
     /**

--- a/common/test/com/commercetools/sunrise/common/suggestion/SunriseProductRecommendationTest.java
+++ b/common/test/com/commercetools/sunrise/common/suggestion/SunriseProductRecommendationTest.java
@@ -6,13 +6,27 @@ import com.commercetools.sunrise.common.controllers.TestableSphereClient;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.models.LocalizedString;
+import io.sphere.sdk.models.Reference;
+import io.sphere.sdk.products.CategoryOrderHints;
 import io.sphere.sdk.products.ProductProjection;
+import io.sphere.sdk.products.ProductVariant;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.reviews.ReviewRatingStatistics;
+import io.sphere.sdk.search.SearchKeywords;
+import io.sphere.sdk.states.State;
+import io.sphere.sdk.taxcategories.TaxCategory;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
+import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SunriseProductRecommendationTest {
@@ -21,6 +35,13 @@ public class SunriseProductRecommendationTest {
     public void getsNoSuggestionsOnEmptyCategories() throws Exception {
         final Set<ProductProjection> recommendedProducts = productRecommendation(TestableSphereClient.ofEmptyResponse())
                 .relatedToCategories(emptyList(), 5).toCompletableFuture().join();
+        assertThat(recommendedProducts).isEmpty();
+    }
+
+    @Test
+    public void getsNoSuggestionsOnEmptyProductCategories() throws Exception {
+        final Set<ProductProjection> recommendedProducts = productRecommendation(TestableSphereClient.ofEmptyResponse())
+                .relatedToProduct(productWithNoCategories(), 5).toCompletableFuture().join();
         assertThat(recommendedProducts).isEmpty();
     }
 
@@ -34,4 +55,128 @@ public class SunriseProductRecommendationTest {
         });
         return injector.getInstance(SunriseProductRecommendation.class);
     }
+
+    private ProductProjection productWithNoCategories() {
+        return new ProductProjection() {
+            @Override
+            public Boolean hasStagedChanges() {
+                return null;
+            }
+
+            @Override
+            public Boolean isPublished() {
+                return null;
+            }
+
+            @Override
+            public Set<Reference<Category>> getCategories() {
+                return emptySet();
+            }
+
+            @Nullable
+            @Override
+            public LocalizedString getDescription() {
+                return null;
+            }
+
+            @Override
+            public ProductVariant getMasterVariant() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public LocalizedString getMetaDescription() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public LocalizedString getMetaKeywords() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public LocalizedString getMetaTitle() {
+                return null;
+            }
+
+            @Override
+            public LocalizedString getName() {
+                return null;
+            }
+
+            @Override
+            public LocalizedString getSlug() {
+                return null;
+            }
+
+            @Override
+            public List<ProductVariant> getVariants() {
+                return null;
+            }
+
+            @Override
+            public SearchKeywords getSearchKeywords() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public CategoryOrderHints getCategoryOrderHints() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public ReviewRatingStatistics getReviewRatingStatistics() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public Reference<State> getState() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public String getKey() {
+                return null;
+            }
+
+            @Override
+            public Reference<ProductType> getProductType() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public Reference<TaxCategory> getTaxCategory() {
+                return null;
+            }
+
+            @Override
+            public String getId() {
+                return null;
+            }
+
+            @Override
+            public Long getVersion() {
+                return null;
+            }
+
+            @Override
+            public ZonedDateTime getCreatedAt() {
+                return null;
+            }
+
+            @Override
+            public ZonedDateTime getLastModifiedAt() {
+                return null;
+            }
+        };
+    }
+
 }

--- a/common/test/com/commercetools/sunrise/common/suggestion/SunriseProductRecommendationTest.java
+++ b/common/test/com/commercetools/sunrise/common/suggestion/SunriseProductRecommendationTest.java
@@ -6,27 +6,14 @@ import com.commercetools.sunrise.common.controllers.TestableSphereClient;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import io.sphere.sdk.categories.Category;
 import io.sphere.sdk.client.SphereClient;
-import io.sphere.sdk.models.LocalizedString;
-import io.sphere.sdk.models.Reference;
-import io.sphere.sdk.products.CategoryOrderHints;
+import io.sphere.sdk.json.SphereJsonUtils;
 import io.sphere.sdk.products.ProductProjection;
-import io.sphere.sdk.products.ProductVariant;
-import io.sphere.sdk.producttypes.ProductType;
-import io.sphere.sdk.reviews.ReviewRatingStatistics;
-import io.sphere.sdk.search.SearchKeywords;
-import io.sphere.sdk.states.State;
-import io.sphere.sdk.taxcategories.TaxCategory;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
-import java.time.ZonedDateTime;
-import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SunriseProductRecommendationTest {
@@ -57,126 +44,7 @@ public class SunriseProductRecommendationTest {
     }
 
     private ProductProjection productWithNoCategories() {
-        return new ProductProjection() {
-            @Override
-            public Boolean hasStagedChanges() {
-                return null;
-            }
-
-            @Override
-            public Boolean isPublished() {
-                return null;
-            }
-
-            @Override
-            public Set<Reference<Category>> getCategories() {
-                return emptySet();
-            }
-
-            @Nullable
-            @Override
-            public LocalizedString getDescription() {
-                return null;
-            }
-
-            @Override
-            public ProductVariant getMasterVariant() {
-                return null;
-            }
-
-            @Nullable
-            @Override
-            public LocalizedString getMetaDescription() {
-                return null;
-            }
-
-            @Nullable
-            @Override
-            public LocalizedString getMetaKeywords() {
-                return null;
-            }
-
-            @Nullable
-            @Override
-            public LocalizedString getMetaTitle() {
-                return null;
-            }
-
-            @Override
-            public LocalizedString getName() {
-                return null;
-            }
-
-            @Override
-            public LocalizedString getSlug() {
-                return null;
-            }
-
-            @Override
-            public List<ProductVariant> getVariants() {
-                return null;
-            }
-
-            @Override
-            public SearchKeywords getSearchKeywords() {
-                return null;
-            }
-
-            @Nullable
-            @Override
-            public CategoryOrderHints getCategoryOrderHints() {
-                return null;
-            }
-
-            @Nullable
-            @Override
-            public ReviewRatingStatistics getReviewRatingStatistics() {
-                return null;
-            }
-
-            @Nullable
-            @Override
-            public Reference<State> getState() {
-                return null;
-            }
-
-            @Nullable
-            @Override
-            public String getKey() {
-                return null;
-            }
-
-            @Override
-            public Reference<ProductType> getProductType() {
-                return null;
-            }
-
-            @Nullable
-            @Override
-            public Reference<TaxCategory> getTaxCategory() {
-                return null;
-            }
-
-            @Override
-            public String getId() {
-                return null;
-            }
-
-            @Override
-            public Long getVersion() {
-                return null;
-            }
-
-            @Override
-            public ZonedDateTime getCreatedAt() {
-                return null;
-            }
-
-            @Override
-            public ZonedDateTime getLastModifiedAt() {
-                return null;
-            }
-        };
+        return SphereJsonUtils.readObject("{\"categories\": [], \"variants\": []}", ProductProjection.class);
     }
 
 }


### PR DESCRIPTION
@mmoelli @jayS-de I had a test to cover the other method (for categories) but for some reason missed the one for products... even though I remember clearly it was the case I wanted to cover 😅 

Anyway, here a quick and effective fix that I will deploy as soon as Travis decides to work again.