### PR TITLE
Fix hbs context factory

### DIFF
--- a/common/app/com/commercetools/sunrise/common/template/engine/handlebars/HandlebarsContextFactory.java
+++ b/common/app/com/commercetools/sunrise/common/template/engine/handlebars/HandlebarsContextFactory.java
@@ -3,6 +3,7 @@ package com.commercetools.sunrise.common.template.engine.handlebars;
 import com.commercetools.sunrise.common.template.engine.TemplateContext;
 import com.commercetools.sunrise.common.utils.ErrorFormatter;
 import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.ValueResolver;
 import com.github.jknack.handlebars.context.JavaBeanValueResolver;
 import com.github.jknack.handlebars.context.MapValueResolver;
@@ -22,26 +23,26 @@ public class HandlebarsContextFactory extends Base {
     @Inject
     private ErrorFormatter errorFormatter;
 
-    public Context create(final TemplateContext templateContext) {
+    public Context create(final Handlebars handlebars, final String templateName, final TemplateContext templateContext) {
         final List<ValueResolver> valueResolvers = valueResolvers(templateContext);
         final Context context = Context.newBuilder(templateContext.pageData())
                 .resolver(valueResolvers.toArray(new ValueResolver[valueResolvers.size()]))
                 .build();
-        fillContext(templateContext, context);
+        fillContext(context, templateContext);
         return context;
     }
 
-    protected void fillContext(final TemplateContext templateContext, final Context context) {
-        fillLocale(templateContext, context);
-        fillCmsPage(templateContext, context);
+    protected void fillContext(final Context context, final TemplateContext templateContext) {
+        fillLocale(context, templateContext);
+        fillCmsPage(context, templateContext);
     }
 
-    protected void fillCmsPage(final TemplateContext templateContext, final Context context) {
+    protected void fillCmsPage(final Context context, final TemplateContext templateContext) {
         templateContext.cmsPage()
                 .ifPresent(cmsPage -> context.data(CMS_PAGE_IN_CONTEXT_KEY, cmsPage));
     }
 
-    protected void fillLocale(final TemplateContext templateContext, final Context context) {
+    protected void fillLocale(final Context context, final TemplateContext templateContext) {
         context.data(LANGUAGE_TAGS_IN_CONTEXT_KEY, templateContext.locales().stream()
                 .map(Locale::toLanguageTag)
                 .collect(toList()));

--- a/common/app/com/commercetools/sunrise/common/template/engine/handlebars/HandlebarsContextFactory.java
+++ b/common/app/com/commercetools/sunrise/common/template/engine/handlebars/HandlebarsContextFactory.java
@@ -1,5 +1,6 @@
 package com.commercetools.sunrise.common.template.engine.handlebars;
 
+import com.commercetools.sunrise.cms.CmsPage;
 import com.commercetools.sunrise.common.template.engine.TemplateContext;
 import com.commercetools.sunrise.common.utils.ErrorFormatter;
 import com.github.jknack.handlebars.Context;
@@ -12,6 +13,7 @@ import io.sphere.sdk.models.Base;
 import javax.inject.Inject;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import static com.commercetools.sunrise.common.template.engine.handlebars.HandlebarsCmsHelper.CMS_PAGE_IN_CONTEXT_KEY;
 import static com.commercetools.sunrise.common.template.engine.handlebars.HandlebarsI18nHelper.LANGUAGE_TAGS_IN_CONTEXT_KEY;
@@ -38,26 +40,34 @@ public class HandlebarsContextFactory extends Base {
         return contextWithCmsPage(contextWithLocale, templateContext);
     }
 
-    protected Context contextWithCmsPage(final Context context, final TemplateContext templateContext) {
-        return templateContext.cmsPage()
+    protected final Context contextWithCmsPage(final Context context, final TemplateContext templateContext) {
+        return cmsPageInContext(templateContext)
                 .map(cmsPage -> context.data(CMS_PAGE_IN_CONTEXT_KEY, cmsPage))
                 .orElse(context);
     }
 
-    protected Context contextWithLocale(final Context context, final TemplateContext templateContext) {
-        return context.data(LANGUAGE_TAGS_IN_CONTEXT_KEY, templateContext.locales().stream()
-                .map(Locale::toLanguageTag)
-                .collect(toList()));
+    protected Optional<CmsPage> cmsPageInContext(final TemplateContext templateContext) {
+        return templateContext.cmsPage();
     }
 
-    protected List<ValueResolver> valueResolvers(final TemplateContext templateContext) {
-        final PlayJavaFormResolver playJavaFormResolver = createPlayJavaFormResolver(templateContext);
-        return asList(MapValueResolver.INSTANCE, JavaBeanValueResolver.INSTANCE, playJavaFormResolver);
+    protected final Context contextWithLocale(final Context context, final TemplateContext templateContext) {
+        return context.data(LANGUAGE_TAGS_IN_CONTEXT_KEY, localesInContext(templateContext));
+    }
+
+    protected List<String> localesInContext(final TemplateContext templateContext) {
+        return templateContext.locales().stream()
+                .map(Locale::toLanguageTag)
+                .collect(toList());
     }
 
     protected final Context.Builder contextBuilderWithValueResolvers(final Context.Builder contextBuilder, final TemplateContext templateContext) {
-        final List<ValueResolver> valueResolvers = valueResolvers(templateContext);
+        final List<ValueResolver> valueResolvers = valueResolversInContext(templateContext);
         return contextBuilder.resolver(valueResolvers.toArray(new ValueResolver[valueResolvers.size()]));
+    }
+
+    protected List<ValueResolver> valueResolversInContext(final TemplateContext templateContext) {
+        final PlayJavaFormResolver playJavaFormResolver = createPlayJavaFormResolver(templateContext);
+        return asList(MapValueResolver.INSTANCE, JavaBeanValueResolver.INSTANCE, playJavaFormResolver);
     }
 
     protected final PlayJavaFormResolver createPlayJavaFormResolver(final TemplateContext templateContext) {

--- a/common/app/com/commercetools/sunrise/common/template/engine/handlebars/HandlebarsContextFactory.java
+++ b/common/app/com/commercetools/sunrise/common/template/engine/handlebars/HandlebarsContextFactory.java
@@ -24,8 +24,8 @@ public class HandlebarsContextFactory extends Base {
     private ErrorFormatter errorFormatter;
 
     public Context create(final Handlebars handlebars, final String templateName, final TemplateContext templateContext) {
-        final Context context = createContextBuilder(templateContext).build();
-        return createContext(context, templateContext);
+        final Context.Builder contextBuilder = createContextBuilder(templateContext);
+        return createContext(contextBuilder, templateContext);
     }
 
     protected final Context.Builder createContextBuilder(final TemplateContext templateContext) {
@@ -33,8 +33,8 @@ public class HandlebarsContextFactory extends Base {
         return contextBuilderWithValueResolvers(contextBuilder, templateContext);
     }
 
-    protected final Context createContext(final Context context, final TemplateContext templateContext) {
-        final Context contextWithLocale = contextWithLocale(context, templateContext);
+    protected final Context createContext(final Context.Builder contextBuilder, final TemplateContext templateContext) {
+        final Context contextWithLocale = contextWithLocale(contextBuilder.build(), templateContext);
         return contextWithCmsPage(contextWithLocale, templateContext);
     }
 

--- a/common/app/com/commercetools/sunrise/common/template/engine/handlebars/HandlebarsTemplateEngine.java
+++ b/common/app/com/commercetools/sunrise/common/template/engine/handlebars/HandlebarsTemplateEngine.java
@@ -26,7 +26,7 @@ public final class HandlebarsTemplateEngine implements TemplateEngine {
     @Override
     public String render(final String templateName, final TemplateContext templateContext) {
         final Template template = compileTemplate(templateName);
-        final Context context = contextFactory.create(templateContext);
+        final Context context = contextFactory.create(handlebars, templateName, templateContext);
         try {
             logger.debug("Rendering template " + templateName);
             return template.apply(context);


### PR DESCRIPTION
Just a little change: the factory was not receiving all information that the HandlebarsTemplateEngine class had available at that moment, limiting a lot the capabilities of this factory. I'm passing now all info.

Of course I could not help but hopefully improving the class a bit before anybody uses it. Such as the order of the arguments and avoid using the HBS Context as a bean, yet keeping the possibility of an easy overriding.

@schleichardt please review