### PR TITLE
implement observer pattern to refresh category subtree upon global category tree refresh

### DIFF
--- a/app/Module.java
+++ b/app/Module.java
@@ -1,5 +1,6 @@
 import com.commercetools.sunrise.cms.CmsService;
 import com.commercetools.sunrise.common.categorytree.CategoryTreeInNewProvider;
+import com.commercetools.sunrise.common.categorytree.CategoryTreeRefresher;
 import com.commercetools.sunrise.common.categorytree.RefreshableCategoryTree;
 import com.commercetools.sunrise.common.contexts.RequestScoped;
 import com.commercetools.sunrise.common.ctp.MetricSphereClientProvider;
@@ -49,6 +50,8 @@ public class Module extends AbstractModule {
         bind(TemplateEngine.class).toProvider(HandlebarsTemplateEngineProvider.class).in(Singleton.class);
         bind(I18nResolver.class).toProvider(ConfigurableI18nResolverProvider.class).in(Singleton.class);
         bind(HttpAuthentication.class).toProvider(BasicAuthenticationProvider.class).in(Singleton.class);
+        bind(CategoryTree.class).to(RefreshableCategoryTree.class);
+        bind(CategoryTreeRefresher.class).to(RefreshableCategoryTree.class);
         bind(CategoryTree.class).annotatedWith(Names.named("new")).toProvider(CategoryTreeInNewProvider.class).in(Singleton.class);
         bind(ProductsPerPageConfig.class).toProvider(ProductsPerPageConfigProvider.class).in(Singleton.class);
         bind(SortConfig.class).toProvider(SortConfigProvider.class).in(Singleton.class);
@@ -57,7 +60,7 @@ public class Module extends AbstractModule {
 
     @Provides
     @Singleton
-    public CategoryTree provideRefreshableCategoryTree(@Named("global") final SphereClient sphereClient) {
+    public RefreshableCategoryTree provideRefreshableCategoryTree(@Named("global") final SphereClient sphereClient) {
         return RefreshableCategoryTree.of(sphereClient);
     }
 

--- a/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeInNewProvider.java
+++ b/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeInNewProvider.java
@@ -27,10 +27,10 @@ public final class CategoryTreeInNewProvider implements Provider<CategoryTree> {
 
     @Override
     public CategoryTree get() {
-        return RefreshableCategorySubtree.of(getBuildStrategy(), categoryTreeRefresher);
+        return RefreshableCategorySubtree.of(buildStrategy(), categoryTreeRefresher);
     }
 
-    private Supplier<CategoryTree> getBuildStrategy() {
+    private Supplier<CategoryTree> buildStrategy() {
         return () -> {
             final List<Category> categories = getCategoryNew(categoryTree)
                     .map(Collections::singletonList)

--- a/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeInNewProvider.java
+++ b/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeInNewProvider.java
@@ -11,6 +11,7 @@ import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public final class CategoryTreeInNewProvider implements Provider<CategoryTree> {
 
@@ -20,20 +21,28 @@ public final class CategoryTreeInNewProvider implements Provider<CategoryTree> {
     @Inject
     private CategoryTree categoryTree;
     @Inject
+    private CategoryTreeRefresher categoryTreeRefresher;
+    @Inject
     private Configuration configuration;
 
     @Override
     public CategoryTree get() {
-        final List<Category> categories = getCategoryNew()
-                .map(Collections::singletonList)
-                .orElseGet(Collections::emptyList);
-        final CategoryTree categoryTreeInNew = categoryTree.getSubtree(categories);
-        logger.info("Provide CategoryTreeInNew with " + categoryTreeInNew.getAllAsFlatList().size() + " categories");
-        return categoryTreeInNew;
+        return RefreshableCategorySubtree.of(getBuildStrategy(), categoryTreeRefresher);
     }
 
-    private Optional<Category> getCategoryNew() {
+    private Supplier<CategoryTree> getBuildStrategy() {
+        return () -> {
+            final List<Category> categories = getCategoryNew(categoryTree)
+                    .map(Collections::singletonList)
+                    .orElseGet(Collections::emptyList);
+            final CategoryTree categoryTreeInNew = categoryTree.getSubtree(categories);
+            logger.info("Provide CategoryTreeInNew with " + categoryTreeInNew.getAllAsFlatList().size() + " categories");
+            return categoryTreeInNew;
+        };
+    }
+
+    private Optional<Category> getCategoryNew(CategoryTree mainTree) {
         return Optional.ofNullable(configuration.getString(CONFIG_CATEGORY_NEW_EXT_ID))
-                .flatMap(extId -> categoryTree.findByExternalId(extId));
+                .flatMap(mainTree::findByExternalId);
     }
 }

--- a/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeRefreshListener.java
+++ b/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeRefreshListener.java
@@ -1,0 +1,8 @@
+package com.commercetools.sunrise.common.categorytree;
+
+/**
+ * An object capable of reacting on refresh of category tree to which it is bound.
+ */
+public interface CategoryTreeRefreshListener {
+    void onRefresh();
+}

--- a/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeRefresher.java
+++ b/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeRefresher.java
@@ -4,5 +4,7 @@ package com.commercetools.sunrise.common.categorytree;
  * An object capable of subscribing listeners interested in reacting to refresh of the category tree which it holds.
  */
 public interface CategoryTreeRefresher {
+    void refresh();
+
     void addListener(CategoryTreeRefreshListener refreshListener);
 }

--- a/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeRefresher.java
+++ b/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeRefresher.java
@@ -1,0 +1,8 @@
+package com.commercetools.sunrise.common.categorytree;
+
+/**
+ * An object capable of subscribing listeners interested in reacting to refresh of the category tree which it holds.
+ */
+public interface CategoryTreeRefresher {
+    void addListener(CategoryTreeRefreshListener refreshListener);
+}

--- a/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeWrapper.java
+++ b/common/app/com/commercetools/sunrise/common/categorytree/CategoryTreeWrapper.java
@@ -1,0 +1,74 @@
+package com.commercetools.sunrise.common.categorytree;
+
+import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.categories.CategoryTree;
+import io.sphere.sdk.models.Base;
+import io.sphere.sdk.models.Identifiable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Thread-safe wrapper for category tree which provides capability of exchanging contained tree reference.
+ */
+public abstract class CategoryTreeWrapper extends Base implements CategoryTree {
+
+    private AtomicReference<CategoryTree> categoryTree = new AtomicReference<>();
+
+    @Override
+    public List<Category> getRoots() {
+        return categoryTree.get().getRoots();
+    }
+
+    @Override
+    public Optional<Category> findById(final String id) {
+        return categoryTree.get().findById(id);
+    }
+
+    @Override
+    public Optional<Category> findByExternalId(final String externalId) {
+        return categoryTree.get().findByExternalId(externalId);
+    }
+
+    @Override
+    public Optional<Category> findBySlug(final Locale locale, final String slug) {
+        return categoryTree.get().findBySlug(locale, slug);
+    }
+
+    @Override
+    public List<Category> getAllAsFlatList() {
+        return categoryTree.get().getAllAsFlatList();
+    }
+
+    @Override
+    public List<Category> findChildren(final Identifiable<Category> category) {
+        return categoryTree.get().findChildren(category);
+    }
+
+    @Override
+    public List<Category> findSiblings(final Collection<? extends Identifiable<Category>> collection) {
+        return categoryTree.get().findSiblings(collection);
+    }
+
+    @Override
+    public CategoryTree getSubtree(final Collection<? extends Identifiable<Category>> collection) {
+        return categoryTree.get().getSubtree(collection);
+    }
+
+    @Override
+    public Category getRootAncestor(final Identifiable<Category> identifiable) {
+        return categoryTree.get().getRootAncestor(identifiable);
+    }
+
+    @Override
+    public List<Category> getSubtreeRoots() {
+        return categoryTree.get().getSubtreeRoots();
+    }
+
+    protected void setCategoryTree(CategoryTree categoryTree) {
+        this.categoryTree.set(categoryTree);
+    }
+}

--- a/common/app/com/commercetools/sunrise/common/categorytree/RefreshableCategorySubtree.java
+++ b/common/app/com/commercetools/sunrise/common/categorytree/RefreshableCategorySubtree.java
@@ -19,7 +19,7 @@ public class RefreshableCategorySubtree extends CategoryTreeWrapper implements C
         onRefresh();
     }
 
-    static CategoryTree of(Supplier<CategoryTree> subtreeBuildStrategy, CategoryTreeRefresher categoryTreeRefresher) {
+    static RefreshableCategorySubtree of(Supplier<CategoryTree> subtreeBuildStrategy, CategoryTreeRefresher categoryTreeRefresher) {
         return new RefreshableCategorySubtree(subtreeBuildStrategy, categoryTreeRefresher);
     }
 

--- a/common/app/com/commercetools/sunrise/common/categorytree/RefreshableCategorySubtree.java
+++ b/common/app/com/commercetools/sunrise/common/categorytree/RefreshableCategorySubtree.java
@@ -1,0 +1,30 @@
+package com.commercetools.sunrise.common.categorytree;
+
+import io.sphere.sdk.categories.CategoryTree;
+
+import java.util.function.Supplier;
+
+/**
+ * A category tree with capabilities of reacting to external refresh action and rebuilding contained tree.
+ */
+public class RefreshableCategorySubtree extends CategoryTreeWrapper implements CategoryTreeRefreshListener {
+
+    private final Supplier<CategoryTree> buildStrategy;
+
+    private RefreshableCategorySubtree(Supplier<CategoryTree> buildStrategy,
+                                       CategoryTreeRefresher categoryTreeRefresher) {
+        this.buildStrategy = buildStrategy;
+        categoryTreeRefresher.addListener(this);
+
+        onRefresh();
+    }
+
+    static CategoryTree of(Supplier<CategoryTree> subtreeBuildStrategy, CategoryTreeRefresher categoryTreeRefresher) {
+        return new RefreshableCategorySubtree(subtreeBuildStrategy, categoryTreeRefresher);
+    }
+
+    @Override
+    public void onRefresh() {
+        setCategoryTree(buildStrategy.get());
+    }
+}

--- a/common/app/com/commercetools/sunrise/common/categorytree/RefreshableCategoryTree.java
+++ b/common/app/com/commercetools/sunrise/common/categorytree/RefreshableCategoryTree.java
@@ -29,6 +29,7 @@ public final class RefreshableCategoryTree extends CategoryTreeWrapper implement
         refresh();
     }
 
+    @Override
     public synchronized void refresh() {
         setCategoryTree(fetchFreshCategoryTree(sphereClient));
         categorySubtrees.forEach(CategoryTreeRefreshListener::onRefresh);

--- a/common/test/com/commercetools/sunrise/common/categorytree/CategoryTreeInNewProviderTest.java
+++ b/common/test/com/commercetools/sunrise/common/categorytree/CategoryTreeInNewProviderTest.java
@@ -1,0 +1,56 @@
+package com.commercetools.sunrise.common.categorytree;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.categories.CategoryTree;
+import io.sphere.sdk.categories.queries.CategoryQuery;
+import org.junit.Test;
+import play.Configuration;
+
+import java.util.Map;
+
+import static com.commercetools.sunrise.common.utils.JsonUtils.readCtpObject;
+import static com.google.inject.name.Names.named;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class CategoryTreeInNewProviderTest {
+
+    @Test
+    public void get() {
+        CategoryTree categoryTree = provideCategoryTree(singletonMap("common.newCategoryExternalId", 1));
+
+        assertThat(categoryTree.getAllAsFlatList()).hasSize(3);
+        assertThat(categoryTree.getRoots()).hasSize(0);
+        assertThat(categoryTree.getSubtreeRoots()).hasSize(1);
+        Category subtreeRoot = categoryTree.getSubtreeRoots().get(0);
+        assertThat(subtreeRoot.getId()).isEqualTo("38429a3d-0cea-4a90-9e72-60ce3681e14e");
+        assertThat(categoryTree.findChildren(subtreeRoot)).hasSize(2);
+    }
+
+    @Test
+    public void get_whenConfigurationMissing() throws Exception {
+        CategoryTree categoryTree = provideCategoryTree(emptyMap());
+
+        assertThat(categoryTree.getAllAsFlatList()).isEmpty();
+    }
+
+    private CategoryTree provideCategoryTree(Map<String, Object> conf) {
+        Injector injector = Guice.createInjector(binder -> {
+            binder.bind(CategoryTree.class).toInstance(mainCategoryTree());
+            binder.bind(CategoryTreeRefresher.class).toInstance(mock(CategoryTreeRefresher.class));
+            binder.bind(Configuration.class).toInstance(new Configuration(conf));
+
+            binder.bind(CategoryTree.class).annotatedWith(named("new")).toProvider(CategoryTreeInNewProvider.class);
+        });
+        return injector.getInstance(Key.get(CategoryTree.class, named("new")));
+    }
+
+    private CategoryTree mainCategoryTree() {
+        return CategoryTree.of(readCtpObject("data/categoriesNew.json", CategoryQuery.resultTypeReference()).getResults());
+    }
+}

--- a/common/test/com/commercetools/sunrise/common/categorytree/RefreshableCategorySubtreeTest.java
+++ b/common/test/com/commercetools/sunrise/common/categorytree/RefreshableCategorySubtreeTest.java
@@ -1,0 +1,56 @@
+package com.commercetools.sunrise.common.categorytree;
+
+import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.categories.CategoryTree;
+import io.sphere.sdk.categories.queries.CategoryQuery;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import static com.commercetools.sunrise.common.utils.JsonUtils.readCtpObject;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RefreshableCategorySubtreeTest {
+
+    @Test
+    public void refresh_verifyNotifyingBehavior() {
+        CategoryTreeRefresher refresher = mock(CategoryTreeRefresher.class);
+        Supplier<CategoryTree> supplier = buildStrategy();
+        RefreshableCategorySubtree categorySubtree = RefreshableCategorySubtree.of(supplier, refresher);
+        RefreshableCategorySubtree subtree = spy(categorySubtree);
+        doAnswer(i -> refresh(subtree)).when(refresher).refresh();
+
+        refresher.refresh();
+
+        verify(refresher).addListener(same(categorySubtree));
+        verify(subtree).onRefresh();
+        verify(supplier, times(2)).get();
+        List<Category> allAsFlatList = subtree.getAllAsFlatList();
+        assertThat(allAsFlatList).hasSize(4);
+        assertThat(allAsFlatList.get(2).getId()).isEqualTo("6043642c-2a75-4be7-9817-a611aad5711a");
+    }
+
+    private Supplier<CategoryTree> buildStrategy() {
+        CategoryTree suppliedOnConstruction = CategoryTree.of(emptyList());
+        CategoryTree suppliedOnRefresh = CategoryTree.of(readCtpObject("data/categories.json", CategoryQuery.resultTypeReference()).getResults());
+        @SuppressWarnings("unchecked")
+        Supplier<CategoryTree> supplier = mock(Supplier.class);
+        when(supplier.get()).thenReturn(suppliedOnConstruction, suppliedOnRefresh);
+        return supplier;
+    }
+
+    private Object refresh(CategoryTreeRefreshListener subtree) {
+        subtree.onRefresh();
+        return null;
+    }
+
+}

--- a/common/test/com/commercetools/sunrise/common/categorytree/RefreshableCategoryTreeTest.java
+++ b/common/test/com/commercetools/sunrise/common/categorytree/RefreshableCategoryTreeTest.java
@@ -1,0 +1,46 @@
+package com.commercetools.sunrise.common.categorytree;
+
+import com.commercetools.sunrise.common.controllers.TestableSphereClient;
+import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.categories.CategoryTree;
+import io.sphere.sdk.categories.queries.CategoryQuery;
+import io.sphere.sdk.queries.PagedQueryResult;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.commercetools.sunrise.common.utils.JsonUtils.readCtpObject;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class RefreshableCategoryTreeTest {
+
+    @Test
+    public void refresh_verifyNotifyingBehavior() {
+        CategoryTreeRefresher refresher = RefreshableCategoryTree.of(TestableSphereClient.ofResponse(PagedQueryResult.empty()));
+        CategoryTreeRefreshListener listener1 = spy(CategoryTreeRefreshListener.class);
+        CategoryTreeRefreshListener listener2 = spy(CategoryTreeRefreshListener.class);
+        refresher.addListener(listener1);
+        refresher.addListener(listener2);
+
+        refresher.refresh();
+
+        verify(listener1).onRefresh();
+        verify(listener2).onRefresh();
+    }
+
+    @Test
+    public void refresh_verifyCategoryTreeIsLoaded_andSorted() {
+        final PagedQueryResult<Category> categories = readCtpObject("data/categories.json", CategoryQuery.resultTypeReference());
+        CategoryTree categoryTree = RefreshableCategoryTree.of(TestableSphereClient.ofResponse(categories));
+
+        ((CategoryTreeRefresher) categoryTree).refresh();
+
+        List<Category> allAsFlatList = categoryTree.getAllAsFlatList();
+        assertThat(allAsFlatList).hasSize(4);
+        assertThat(allAsFlatList.get(2).getId()).isEqualTo("7e06b4a0-d9d9-436e-beb6-3cdaaeccdef8");
+        assertThat(allAsFlatList.get(3).getId()).isEqualTo("6043642c-2a75-4be7-9817-a611aad5711a");
+    }
+
+}

--- a/common/test/resources/data/categoriesNew.json
+++ b/common/test/resources/data/categoriesNew.json
@@ -16,12 +16,12 @@
             "description": {
                 "en": "<p>1st-level category</p>"
             },
-            "ancestors": [],
-            "orderHint": "0.000014482755315751697271913"
+            "ancestors": []
         },
         {
             "id": "38429a3d-0cea-4a90-9e72-60ce3681e14e",
             "version": 1,
+            "externalId": "1",
             "name": {
                 "en": "2nd Level"
             },
@@ -41,8 +41,7 @@
             "parent": {
                 "typeId": "category",
                 "id": "ebca0e07-ffc7-4a59-ba8a-57338f9d34bf"
-            },
-            "orderHint": "0.000014482755573631702989662"
+            }
         },
         {
             "id": "6043642c-2a75-4be7-9817-a611aad5711a",
@@ -70,8 +69,7 @@
             "parent": {
                 "typeId": "category",
                 "id": "38429a3d-0cea-4a90-9e72-60ce3681e14e"
-            },
-            "orderHint": "0.000014482756280411677827979"
+            }
         },
         {
             "id": "7e06b4a0-d9d9-436e-beb6-3cdaaeccdef8",
@@ -99,8 +97,7 @@
             "parent": {
                 "typeId": "category",
                 "id": "38429a3d-0cea-4a90-9e72-60ce3681e14e"
-            },
-            "orderHint": "0.000014482755893701838050132"
+            }
         }
     ]
 }

--- a/product-catalog/pt/com/commercetools/sunrise/productcatalog/ProductCatalogTestModule.java
+++ b/product-catalog/pt/com/commercetools/sunrise/productcatalog/ProductCatalogTestModule.java
@@ -1,6 +1,7 @@
 package com.commercetools.sunrise.productcatalog;
 
 import com.commercetools.sunrise.common.DefaultTestModule;
+import com.commercetools.sunrise.common.categorytree.CategoryTreeRefresher;
 import com.commercetools.sunrise.common.controllers.TestableReverseRouter;
 import com.commercetools.sunrise.common.ctp.ProductDataConfig;
 import com.commercetools.sunrise.common.reverserouter.HomeReverseRouter;
@@ -25,6 +26,7 @@ public class ProductCatalogTestModule extends DefaultTestModule {
         super.configure();
         bind(ProductDataConfig.class).toInstance(ProductDataConfig.of(null, emptyList(), emptyList(), emptyList()));
         bind(CategoryTree.class).toInstance(CategoryTree.of(emptyList()));
+        bind(CategoryTreeRefresher.class).toInstance(refreshListener -> {});
         bind(CategoryTree.class).annotatedWith(Names.named("new")).toInstance(CategoryTree.of(emptyList()));
         bind(HomeReverseRouter.class).toInstance(new TestableReverseRouter());
         bind(ProductReverseRouter.class).toInstance(new TestableReverseRouter());

--- a/product-catalog/pt/com/commercetools/sunrise/productcatalog/ProductCatalogTestModule.java
+++ b/product-catalog/pt/com/commercetools/sunrise/productcatalog/ProductCatalogTestModule.java
@@ -18,6 +18,7 @@ import java.util.concurrent.CompletionStage;
 
 import static io.sphere.sdk.utils.CompletableFutureUtils.exceptionallyCompletedFuture;
 import static java.util.Collections.emptyList;
+import static org.mockito.Mockito.mock;
 
 public class ProductCatalogTestModule extends DefaultTestModule {
 
@@ -26,7 +27,7 @@ public class ProductCatalogTestModule extends DefaultTestModule {
         super.configure();
         bind(ProductDataConfig.class).toInstance(ProductDataConfig.of(null, emptyList(), emptyList(), emptyList()));
         bind(CategoryTree.class).toInstance(CategoryTree.of(emptyList()));
-        bind(CategoryTreeRefresher.class).toInstance(refreshListener -> {});
+        bind(CategoryTreeRefresher.class).toInstance(mock(CategoryTreeRefresher.class));
         bind(CategoryTree.class).annotatedWith(Names.named("new")).toInstance(CategoryTree.of(emptyList()));
         bind(HomeReverseRouter.class).toInstance(new TestableReverseRouter());
         bind(ProductReverseRouter.class).toInstance(new TestableReverseRouter());

--- a/project/TestCommon.scala
+++ b/project/TestCommon.scala
@@ -30,7 +30,8 @@ object TestCommon {
     libraryDependencies ++= Seq (
       "org.assertj" % "assertj-core" % "3.0.0" % scopes,
       "com.commercetools.sdk.jvm.core" % "commercetools-test-lib" % "1.0.0-RC2" % scopes,
-      PlayImport.component("play-test") % scopes
+      PlayImport.component("play-test") % scopes,
+      "org.mockito" % "mockito-core" % "1.10.19"
     ),
     dependencyOverrides ++= Set (
       "junit" % "junit" % "4.12" % scopes


### PR DESCRIPTION
#411 
@lauraluiz please, review

Changes consist of wrapper class that enables thread-safe exchanging of contained category tree.
Observer pattern implementation enables registering and notifying interested listeners (in that case category sub-trees) upon refresh events. The refreshed object notifies its listener which rebuilds it's subtree based on fresh global category tree.

Because of split interfaces projects based on sunrise would need to adjust its guice configuration the same way it was done in this PR.