### PR TITLE
Travis without docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ before_cache:
 
 script:
 - sbt compile test it:test pt:test unidoc
-- ls -l
-- sudo chown -R travis:travis /home/travis
-- ls -l
 - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then ./sbt
   "gitPublish target/javaunidoc https://$GH_TOKEN:x-oauth-basic@github.com/$TRAVIS_REPO_SLUG.git
   javadoc sphere-oss automation@commercetools.de"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ jdk:
 - oraclejdk8
 
 cache:
-  # md5deep - https://github.com/travis-ci/travis-ci/issues/3122
+  # md5deep
+  # - https://github.com/travis-ci/travis-ci/issues/3122
+  # - https://github.com/travis-ci/travis-ci/issues/3039
   branch: md5deep
   directories:
     - $HOME/.ivy2/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,21 @@
 sudo: required
+dist: trusty
+
 language: scala
 scala:
 - 2.11.7
-services:
-  - docker
-before_install:
-- docker pull java:8u92-jdk-alpine
-- wget https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.11/sbt-launch.jar
-- echo 'java -Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M -jar sbt-launch.jar "$@"' > sbt.sh
+jdk:
+- oraclejdk8
+
 script:
-- "docker run -it --rm -e SUNRISE_IT_CTP_PROJECT_KEY=$SUNRISE_IT_CTP_PROJECT_KEY -e SUNRISE_IT_CTP_CLIENT_ID=$SUNRISE_IT_CTP_CLIENT_ID -e SUNRISE_IT_CTP_CLIENT_SECRET=$SUNRISE_IT_CTP_CLIENT_SECRET --volume=$(pwd):/src --volume=/home/travis/.ivy2:/ivy2  --volume=/home/travis/.sbt:/sbt -w /src java:8u92-jdk-alpine sh sbt.sh compile test it:test pt:test unidoc"
-#- rm conf/dev.conf Enable setup widget first
+- sbt compile test it:test pt:test unidoc
 - ls -l
 - sudo chown -R travis:travis /home/travis
 - ls -l
 - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then ./sbt
   "gitPublish target/javaunidoc https://$GH_TOKEN:x-oauth-basic@github.com/$TRAVIS_REPO_SLUG.git
   javadoc sphere-oss automation@commercetools.de"; fi
-jdk:
-- oraclejdk8
-env:
-  matrix:
-  - SBT_OPTS="-XX:PermSize=512M -XX:MaxPermSize=1024M"
+
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,17 @@ scala:
 jdk:
 - oraclejdk8
 
+cache:
+  # md5deep - https://github.com/travis-ci/travis-ci/issues/3122
+  branch: md5deep
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
+
 script:
 - sbt compile test it:test pt:test unidoc
 - ls -l

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: required
 dist: trusty
+sudo: false
 
 language: scala
 scala:


### PR DESCRIPTION
Remove docker from our build, switched to container based build environment using trusty distribution which currently provides jdk8u111. 
Added caching of sbt dependencies which hopefully makes our build more stable and faster.