### PR TITLE
Add "unstable" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Sunrise Java Shop Framework :sunrise:
 
 [![Build Status](https://travis-ci.org/commercetools/commercetools-sunrise-java.svg?branch=master)](https://travis-ci.org/commercetools/commercetools-sunrise-java)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.commercetools.sunrise/product-catalog_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.commercetools.sunrise/product-catalog_2.11)
+[![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)](https://github.com/orangemug/stability-badges)
 [![Heroku](http://heroku-badge.herokuapp.com/?app=ct-sunrise-prod&style=flat&svg=1)](http://ct-sunrise-prod.herokuapp.com/)
 [![Stories in Ready](https://badge.waffle.io/commercetools/commercetools-sunrise-java.svg?label=in+progress&title=waffle.io)](https://waffle.io/commercetools/commercetools-sunrise-java)
 


### PR DESCRIPTION
I have added the badge.
Now questions:
- Should we link to the badge documentation to have an explanation of what does every definition imply? (current)
- Should we have this explanation copied in README instead?
- Another suggestion?