### PR TITLE
Disable matching variants

### DIFF
--- a/app/Module.java
+++ b/app/Module.java
@@ -16,7 +16,8 @@ import com.commercetools.sunrise.framework.template.i18n.I18nResolver;
 import com.commercetools.sunrise.framework.viewmodels.content.carts.MiniCartViewModelFactory;
 import com.commercetools.sunrise.httpauth.HttpAuthentication;
 import com.commercetools.sunrise.httpauth.basic.BasicAuthenticationProvider;
-import com.commercetools.sunrise.productcatalog.productoverview.search.facetedsearch.categorytree.viewmodels.CategoryTreeFacetViewModelFactory;
+import com.commercetools.sunrise.productcatalog.productoverview.ProductListFinder;
+import com.commercetools.sunrise.productcatalog.productoverview.ProductListFinderByCategoryWithMatchingVariants;
 import com.commercetools.sunrise.search.facetedsearch.terms.viewmodels.AlphabeticallySortedTermFacetViewModelFactory;
 import com.commercetools.sunrise.search.facetedsearch.terms.viewmodels.CustomSortedTermFacetViewModelFactory;
 import com.commercetools.sunrise.search.facetedsearch.terms.viewmodels.TermFacetViewModelFactory;
@@ -105,6 +106,10 @@ public class Module extends AbstractModule {
 
         // Binding to truncate mini cart to fit it into limited session space
         bind(MiniCartViewModelFactory.class).to(TruncatedMiniCartViewModelFactory.class);
+
+        // Binding to enable matching variants on listing products
+        // IMPORTANT: comment the following line if your project does not require this functionality, leaving it on can severely affect performance
+        bind(ProductListFinder.class).to(ProductListFinderByCategoryWithMatchingVariants.class);
 
         // Provide here your own bindings
     }

--- a/common/app/com/commercetools/sunrise/common/healthcheck/SunriseHealthCheckController.java
+++ b/common/app/com/commercetools/sunrise/common/healthcheck/SunriseHealthCheckController.java
@@ -27,7 +27,9 @@ public abstract class SunriseHealthCheckController extends SunriseController {
     }
 
     public CompletionStage<Result> show() throws IOException {
-        final ProductProjectionSearch productRequest = ProductProjectionSearch.ofCurrent().withLimit(1);
+        final ProductProjectionSearch productRequest = ProductProjectionSearch.ofCurrent()
+                .withMarkingMatchingVariants(false)
+                .withLimit(1);
         return sphereClient.execute(productRequest)
                 .thenApplyAsync(this::renderGoodHealthStatus, HttpExecution.defaultContext())
                 .exceptionally(this::renderBadHealthStatus)

--- a/common/app/com/commercetools/sunrise/recommendations/DefaultProductRecommender.java
+++ b/common/app/com/commercetools/sunrise/recommendations/DefaultProductRecommender.java
@@ -91,6 +91,7 @@ public class DefaultProductRecommender implements ProductRecommender {
                 .withLimit(numProducts)
                 .withQueryFilters(product -> product.categories().id().containsAny(categoryIds))
                 .withSort(product -> product.allVariants().price().desc())
+                .withMarkingMatchingVariants(false)
                 .withPriceSelection(priceSelection);
         return sphereClient.execute(request)
                 .whenCompleteAsync((result, t) -> LOGGER.debug(printableProductRequest(request, result)), HttpExecution.defaultContext())

--- a/product-catalog/app/com/commercetools/sunrise/productcatalog/productdetail/ProductFinderById.java
+++ b/product-catalog/app/com/commercetools/sunrise/productcatalog/productdetail/ProductFinderById.java
@@ -27,6 +27,7 @@ public class ProductFinderById extends AbstractSingleProductSearchExecutor imple
 
     protected ProductProjectionSearch buildRequest(final String id) {
         return ProductProjectionSearch.ofCurrent()
+                .withMarkingMatchingVariants(false)
                 .withQueryFilters(m -> m.id().is(id))
                 .withPriceSelection(priceSelection);
     }

--- a/product-catalog/app/com/commercetools/sunrise/productcatalog/productdetail/ProductFinderBySlug.java
+++ b/product-catalog/app/com/commercetools/sunrise/productcatalog/productdetail/ProductFinderBySlug.java
@@ -31,6 +31,7 @@ public class ProductFinderBySlug extends AbstractSingleProductSearchExecutor imp
 
     protected ProductProjectionSearch buildRequest(final String slug) {
         return ProductProjectionSearch.ofCurrent()
+                .withMarkingMatchingVariants(false)
                 .withQueryFilters(m -> m.slug().locale(locale).is(slug))
                 .withPriceSelection(priceSelection);
     }

--- a/product-catalog/app/com/commercetools/sunrise/productcatalog/productoverview/ProductListFinderByCategory.java
+++ b/product-catalog/app/com/commercetools/sunrise/productcatalog/productoverview/ProductListFinderByCategory.java
@@ -30,6 +30,7 @@ public class ProductListFinderByCategory extends AbstractProductSearchExecutor i
     protected ProductProjectionSearch buildRequest(@Nullable final Category category) {
         // In our case category is filtered via faceted search
         return ProductProjectionSearch.ofCurrent()
+                .withMarkingMatchingVariants(false)
                 .withPriceSelection(priceSelection);
     }
 }

--- a/product-catalog/app/com/commercetools/sunrise/productcatalog/productoverview/ProductListFinderByCategoryWithMatchingVariants.java
+++ b/product-catalog/app/com/commercetools/sunrise/productcatalog/productoverview/ProductListFinderByCategoryWithMatchingVariants.java
@@ -1,0 +1,25 @@
+package com.commercetools.sunrise.productcatalog.productoverview;
+
+import com.commercetools.sunrise.framework.hooks.HookRunner;
+import io.sphere.sdk.categories.Category;
+import io.sphere.sdk.client.SphereClient;
+import io.sphere.sdk.products.search.PriceSelection;
+import io.sphere.sdk.products.search.ProductProjectionSearch;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+public final class ProductListFinderByCategoryWithMatchingVariants extends ProductListFinderByCategory {
+
+    @Inject
+    ProductListFinderByCategoryWithMatchingVariants(final SphereClient sphereClient, final HookRunner hookRunner,
+                                                    final PriceSelection priceSelection) {
+        super(sphereClient, hookRunner, priceSelection);
+    }
+
+    @Override
+    protected ProductProjectionSearch buildRequest(@Nullable final Category category) {
+        return super.buildRequest(category)
+                .withMarkingMatchingVariants(true);
+    }
+}


### PR DESCRIPTION
Disable it on all search calls and provide a way to enable it in POP (which is enabled by default to provide better results, but can be easily removed as suggested).