### PR TITLE
Fix pagination total pages

### DIFF
--- a/common/app/com/commercetools/sunrise/search/pagination/viewmodels/AbstractPaginationViewModelFactory.java
+++ b/common/app/com/commercetools/sunrise/search/pagination/viewmodels/AbstractPaginationViewModelFactory.java
@@ -121,11 +121,11 @@ public abstract class AbstractPaginationViewModelFactory extends ViewModelFactor
         return Math.min(currentPage + paginationSettings.getDisplayedPages(), totalPages);
     }
 
-    private long calculateTotalPages(final PagedResult<?> pagedResult, final long currentPage) {
+    static long calculateTotalPages(final PagedResult<?> pagedResult, final long currentPage) {
         if (pagedResult.isLast()) {
             return currentPage;
         } else if (pagedResult.getCount() > 0) {
-            final Double totalPages = Math.ceil(pagedResult.getTotal() / pagedResult.getCount());
+            final Double totalPages = Math.ceil(pagedResult.getTotal().doubleValue() / pagedResult.getCount().doubleValue());
             return totalPages.longValue();
         } else {
             return 0;

--- a/common/app/com/commercetools/sunrise/search/pagination/viewmodels/AbstractPaginationViewModelFactory.java
+++ b/common/app/com/commercetools/sunrise/search/pagination/viewmodels/AbstractPaginationViewModelFactory.java
@@ -125,7 +125,7 @@ public abstract class AbstractPaginationViewModelFactory extends ViewModelFactor
         if (pagedResult.isLast()) {
             return currentPage;
         } else if (pagedResult.getCount() > 0) {
-            final Double totalPages = Math.ceil(pagedResult.getTotal().doubleValue() / pagedResult.getCount().doubleValue());
+            final Double totalPages = Math.ceil(pagedResult.getTotal() / pagedResult.getCount().doubleValue());
             return totalPages.longValue();
         } else {
             return 0;


### PR DESCRIPTION
Fixed an error reported in which the last page was usually not listed due to division of `Long` returning a non-decimal value, therefore `ceil` method was not able to round up.
Also provided tests and cleaned up a bit the other tests.
Will release in a fix version as soon as it's merged.